### PR TITLE
Switch from the deprecated distutils module to the packaging module

### DIFF
--- a/.gitlab-ci/debian-stable.Dockerfile
+++ b/.gitlab-ci/debian-stable.Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -qq -y \
     locales \
     ninja-build \
     python3 \
+    python3-packaging \
     python3-pip \
     python3-setuptools \
     python3-wheel \

--- a/.gitlab-ci/fedora.Dockerfile
+++ b/.gitlab-ci/fedora.Dockerfile
@@ -45,6 +45,7 @@ RUN dnf -y update \
     ninja-build \
     pcre2-devel \
     "python3-dbusmock >= 0.18.3-2" \
+    python3-packaging \
     python3-pip \
     python3-pygments \
     python3-wheel \

--- a/gio/gdbus-2.0/codegen/utils.py
+++ b/gio/gdbus-2.0/codegen/utils.py
@@ -19,7 +19,7 @@
 #
 # Author: David Zeuthen <davidz@redhat.com>
 
-import distutils.version
+import packaging.version
 import os
 import sys
 
@@ -162,4 +162,4 @@ def version_cmp_key(key):
         v = str(key[0])
     else:
         v = "0"
-    return (distutils.version.LooseVersion(v), key[1])
+    return (packaging.version.Version(v), key[1])


### PR DESCRIPTION
The distutils module was removed in Python 3.12.

(cherry picked from commit 6ef967a0f930ce37a8c9b5aff969693b34714291)